### PR TITLE
Add support for explicit plus sign

### DIFF
--- a/shunting_yard.cpp
+++ b/shunting_yard.cpp
@@ -59,7 +59,7 @@ vector<Token *> parse(const string &expression) {
 
 bool shouldParseAsOperator(const string &expression, int position) {
     char c = expression[position];
-    if (c != '-') {
+    if (c != '-' && c != '+') {
         return Operator::isOperator(c);
     }
 


### PR DESCRIPTION
Expressions like `5 / (+3)` and `+1 + 2` are totally valid, so we should support them.

Again, branch [shunting_test](https://github.com/Leonidius20/ITP_S2_Lab3/tree/shunting_test/) is available for testing.